### PR TITLE
An 'Allow' header is mandatory in error 405

### DIFF
--- a/lib/Plack/App/RDF/Files.pm
+++ b/lib/Plack/App/RDF/Files.pm
@@ -154,7 +154,7 @@ sub call {
     my ($self, $env) = @_;
     my $req = Plack::Request->new($env);
 
-    return [405, ['Content-type' => 'text/plain'], ['Method not allowed']]
+    return [405, ['Content-type' => 'text/plain', 'Allow' => 'GET,HEAD'], ['Method not allowed']]
         unless (($req->method eq 'GET') || ($req->method eq 'HEAD'));
 
     # find out which RDF files to retrieve


### PR DESCRIPTION
see http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6 and https://tools.ietf.org/html/rfc7231#section-6.5.5
